### PR TITLE
Fix the value of AirVolumeAuto

### DIFF
--- a/aircon.go
+++ b/aircon.go
@@ -78,7 +78,7 @@ func (v AirVolume) StringValue() string {
 
 const (
 	// AirVolumeAuto represents auto.
-	AirVolumeAuto = ""
+	AirVolumeAuto = "auto"
 	// AirVolume1 represents volume 1.
 	AirVolume1 = "1"
 	// AirVolume2 represents volume 2.


### PR DESCRIPTION
The value of `AirVolumeAuto` is set to empty in `aircon.go`, but `UpdateAirConSettings` method does not work with this. When we update air conditioner settings to `auto` air volume, it seems that we have to set `air_volume=auto` explicitly.

Example with `curl`

```
$ curl -X POST "https://api.nature.global/1/appliances/XXXXXXXXXX/aircon_settings" -H "accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "air_volume=3" -H "Authorization: Bearer MY_TOKEN"
{"temp":"22","mode":"warm","vol":"3","dir":"","button":"","updated_at":"2019-01-28T14:10:39Z"}

$ curl -X POST "https://api.nature.global/1/appliances/XXXXXXXXXX/aircon_settings" -H "accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "air_volume=auto" -H "Authorization: Bearer MY_TOKEN"
{"temp":"22","mode":"warm","vol":"auto","dir":"","button":"","updated_at":"2019-01-28T14:10:43Z"}

$ curl -X POST "https://api.nature.global/1/appliances/XXXXXXXXXX/aircon_settings" -H "accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "air_volume=3" -H "Authorization: Bearer MY_TOKEN"
{"temp":"22","mode":"warm","vol":"3","dir":"","button":"","updated_at":"2019-01-28T14:10:45Z"}

$ curl -X POST "https://api.nature.global/1/appliances/XXXXXXXXXX/aircon_settings" -H "accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "air_volume=" -H "Authorization: Bearer MY_TOKEN"
{"temp":"22","mode":"warm","vol":"3","dir":"","button":"","updated_at":"2019-01-28T14:11:01Z"}
```

I have found this library in Software Design 2019-02. Thanks for the good library and article.