### PR TITLE
Always set own User-Agent on each request

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,12 @@ const (
 	apiVersion = "1"
 )
 
+var defaultUserAgent string
+
+func init() {
+	defaultUserAgent = "tenntenn-natureremo/" + version + " (+https://github.com/tenntenn/natureremo)"
+}
+
 // Client is an API client for Nature Remo Cloud API.
 type Client struct {
 	UserService      UserService
@@ -46,7 +52,15 @@ func NewClient(accessToken string) *Client {
 	cli.ApplianceService = &applianceService{cli: &cli}
 	cli.SignalService = &signalService{cli: &cli}
 	cli.BaseURL = baseURL + apiVersion
+	cli.UserAgent = defaultUserAgent
 	return &cli
+}
+
+func (cli *Client) getUA() string {
+	if cli.UserAgent != "" {
+		return cli.UserAgent
+	}
+	return defaultUserAgent
 }
 
 func (cli *Client) httpClient() *http.Client {
@@ -59,6 +73,7 @@ func (cli *Client) httpClient() *http.Client {
 func (cli *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req = req.WithContext(ctx)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cli.AccessToken))
+	req.Header.Set("User-Agent", cli.getUA())
 	return cli.httpClient().Do(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const version = "0.0.1"
+
 const (
 	baseURL    = "https://api.nature.global/"
 	apiVersion = "1"

--- a/client.go
+++ b/client.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	baseURL = "https://api.nature.global/"
-	version = "1"
+	baseURL    = "https://api.nature.global/"
+	apiVersion = "1"
 )
 
 // Client is an API client for Nature Remo Cloud API.
@@ -30,6 +30,7 @@ type Client struct {
 	HTTPClient    *http.Client
 	AccessToken   string
 	BaseURL       string
+	UserAgent     string
 	LastRateLimit *RateLimit
 }
 
@@ -42,7 +43,7 @@ func NewClient(accessToken string) *Client {
 	cli.DeviceService = &deviceService{cli: &cli}
 	cli.ApplianceService = &applianceService{cli: &cli}
 	cli.SignalService = &signalService{cli: &cli}
-	cli.BaseURL = baseURL + version
+	cli.BaseURL = baseURL + apiVersion
 	return &cli
 }
 


### PR DESCRIPTION
I appreciate you to create this great library.

Sorry to point such trivial details, in general, it is preferable to set an own User-Agent header in a client library, and I implemented around `client.UserAgent` to support it.

Since the `version` constant has been defined, sync with the git tag may be bothering, but please devise with release engineering. I'm using `gobump` for it.