### PR TITLE
Add supported API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ http://swagger.nature.global
 |:heavy_check_mark:|/1/appliances/{appliance}/delete         | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
 |:heavy_check_mark:|/1/appliances/{appliance}                | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
 |:heavy_check_mark:|/1/appliances/{appliance}/aircon_settings| POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
-|                  |/1/appliances/{appliance}/tv             | POST        |                                                                                     |
-|                  |/1/appliances/{appliance}/light          | POST        |                                                                                     |
+|:heavy_check_mark:|/1/appliances/{appliance}/tv             | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
+|:heavy_check_mark:|/1/appliances/{appliance}/light          | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
 |:heavy_check_mark:|/1/appliances/{appliance}/signals        | GET         |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |
 |:heavy_check_mark:|/1/appliances/{appliance}/signals        | POST        |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |
 |:heavy_check_mark:|/1/appliances/{appliance}/signal_orders  | POST        |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ http://swagger.nature.global
 |:heavy_check_mark:|/1/appliances/{appliance}/delete         | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
 |:heavy_check_mark:|/1/appliances/{appliance}                | POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
 |:heavy_check_mark:|/1/appliances/{appliance}/aircon_settings| POST        |[ApplianceService](https://godoc.org/github.com/tenntenn/natureremo#ApplianceService)|
+|                  |/1/appliances/{appliance}/tv             | POST        |                                                                                     |
+|                  |/1/appliances/{appliance}/light          | POST        |                                                                                     |
 |:heavy_check_mark:|/1/appliances/{appliance}/signals        | GET         |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |
 |:heavy_check_mark:|/1/appliances/{appliance}/signals        | POST        |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |
 |:heavy_check_mark:|/1/appliances/{appliance}/signal_orders  | POST        |[SignalService](https://godoc.org/github.com/tenntenn/natureremo#SignalService)   |

--- a/appliance.go
+++ b/appliance.go
@@ -12,6 +12,8 @@ type Appliance struct {
 	Signals        []*Signal       `json:"signals"`
 	AirConSettings *AirConSettings `json:"settings"`
 	AirCon         *AirCon         `json:"aircon"`
+	TV             *TV             `json:"tv"`
+	Light          *Light          `json:"light"`
 }
 
 // SignalByName gets a signal by name from Signals.
@@ -32,6 +34,10 @@ type ApplianceType string
 const (
 	// ApplianceTypeAirCon represents an air conditioner.
 	ApplianceTypeAirCon ApplianceType = "AC"
+	// ApplianceTypeTV represents an TV
+	ApplianceTypeTV ApplianceType = "TV"
+	// ApplianceTypeLight represents Light
+	ApplianceTypeLight ApplianceType = "LIGHT"
 	// ApplianceTypeIR represents a device which is controlled by infrared.
 	ApplianceTypeIR ApplianceType = "IR"
 )

--- a/appliance_service.go
+++ b/appliance_service.go
@@ -29,6 +29,8 @@ type ApplianceService interface {
 	Update(ctx context.Context, appliance *Appliance) (*Appliance, error)
 	// UpdateAirConSettings updates air conditioner settings of specified appliance.
 	UpdateAirConSettings(ctx context.Context, appliance *Appliance, settings *AirConSettings) error
+	// SendTVSignal sends TV infrared signal.
+	SendTVSignal(ctx context.Context, appliance *Appliance, buttonName string) (*TVState, error)
 }
 
 type applianceService struct {
@@ -129,4 +131,17 @@ func (s *applianceService) UpdateAirConSettings(ctx context.Context, appliance *
 		return errors.Wrapf(err, "POST %s with %#v", path, data)
 	}
 	return nil
+}
+
+func (s *applianceService) SendTVSignal(ctx context.Context, appliance *Appliance, buttonName string) (*TVState, error) {
+	path := fmt.Sprintf("appliances/%s/tv", appliance.ID)
+
+	data := url.Values{}
+	data.Set("button", buttonName)
+
+	var status TVState
+	if err := s.cli.postForm(ctx, path, data, &status); err != nil {
+		return nil, errors.Wrapf(err, "POST %s with %#v", path, data)
+	}
+	return &status, nil
 }

--- a/appliance_service.go
+++ b/appliance_service.go
@@ -31,6 +31,8 @@ type ApplianceService interface {
 	UpdateAirConSettings(ctx context.Context, appliance *Appliance, settings *AirConSettings) error
 	// SendTVSignal sends TV infrared signal.
 	SendTVSignal(ctx context.Context, appliance *Appliance, buttonName string) (*TVState, error)
+	// SendLightSignal sends light infrared signal.
+	SendLightSignal(ctx context.Context, appliance *Appliance, buttonName string) (*LightState, error)
 }
 
 type applianceService struct {
@@ -140,6 +142,19 @@ func (s *applianceService) SendTVSignal(ctx context.Context, appliance *Applianc
 	data.Set("button", buttonName)
 
 	var status TVState
+	if err := s.cli.postForm(ctx, path, data, &status); err != nil {
+		return nil, errors.Wrapf(err, "POST %s with %#v", path, data)
+	}
+	return &status, nil
+}
+
+func (s *applianceService) SendLightSignal(ctx context.Context, appliance *Appliance, buttonName string) (*LightState, error) {
+	path := fmt.Sprintf("appliances/%s/light", appliance.ID)
+
+	data := url.Values{}
+	data.Set("button", buttonName)
+
+	var status LightState
 	if err := s.cli.postForm(ctx, path, data, &status); err != nil {
 		return nil, errors.Wrapf(err, "POST %s with %#v", path, data)
 	}

--- a/default_button.go
+++ b/default_button.go
@@ -1,0 +1,8 @@
+package natureremo
+
+// DefaultButton is defined by Nature.inc? or defined at IRDB?
+type DefaultButton struct {
+	Name  string
+	Image string
+	Label string
+}

--- a/light.go
+++ b/light.go
@@ -1,0 +1,13 @@
+package natureremo
+
+type Light struct {
+	State   *LightState
+	Buttons []DefaultButton
+}
+
+// LightState is Light state
+type LightState struct {
+	Brightness string `json:"brightness"`
+	Power      string `json:"power"`
+	LastButton string `json:"last_button"`
+}

--- a/tv.go
+++ b/tv.go
@@ -1,0 +1,19 @@
+package natureremo
+
+type TV struct {
+	State   *TVState
+	Buttons []DefaultButton
+}
+
+// TVState is TV state
+type TVState struct {
+	Input TVInputType `json:"input"`
+}
+
+type TVInputType string
+
+const (
+	TVInputTypeT  TVInputType = "t"
+	TVInputTypeBS TVInputType = "bs"
+	TVInputTypeCS TVInputType = "cs"
+)


### PR DESCRIPTION
[Official document](http://swagger.nature.global) said api has more two endpoint, [`​/1​/appliances​/{appliance}​/tv`](http://swagger.nature.global/#/default/post_1_appliances__appliance__tv) and [`​/1​/appliances​/{appliance}​/light`](http://swagger.nature.global/#/default/post_1_appliances__appliance__light).

Additionally, this PR is enable to get status of TV or Light with ApplianceService.GetAll.